### PR TITLE
[bugfix]修复博客中部分文章及图片无法访问的问题

### DIFF
--- a/WebService/urls.py
+++ b/WebService/urls.py
@@ -16,5 +16,6 @@ urlpatterns = [
     path('blog/', include('WebService.Blog.urls')),
     path('filescube/', include('WebService.FilesCube.urls')),
     path('starry/', include('WebService.Starry.urls')),
+    url(r'(.*)$', webservice_views.redirect),
     # url(r'^(?P<path>.*)$', serve, {'document_root': 'FilesCube/static/easyui'}),
 ]

--- a/WebService/views.py
+++ b/WebService/views.py
@@ -3,8 +3,19 @@ Author: Baixu
 Date: 2020-07-10
 Desc: 网站主入口的视图函数
 """
+from django.http import HttpResponseRedirect
 from django.shortcuts import render
 
 
 def homepage(request):
     return render(request, 'homepage.html')
+
+
+def redirect(request, path):
+    """
+    所有url均匹配失效时调用该函数，通知用户重定向至对应的https链接再尝试一次
+    :param path: 用户提交的url
+    :param request: WSGI对象，用户的这次网络请求
+    :return: 重定向的回复
+    """
+    return HttpResponseRedirect('https://7venminutes.com/' + path)


### PR DESCRIPTION
webservice占用80端口，wordpress占用443端口，在点击wordpress中的http链接时，请求会跳转到webservice上。这也是博客中图片和部分文章链接会挂的根本原因。

本次bugfix 将 所有无法匹配url的请求全部重定向到443接口，可以暂时性修复该问题，但为日后可能的url冲突埋下了隐患。wordpress和webservice分离到两个机器上部署时，需把本次修改中的改动更改回来。